### PR TITLE
Fix #6 Foreman should not be added to Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Default calls
  * capify
  * cucumber
  * dashing
- * foreman
  * guard
  * kitchen
  * middleman
@@ -67,7 +66,7 @@ $ guard -i
 or
 
 ```fish
-$ foreman start
+$ ruby -v
 ```
 
 License

--- a/bundler.fish
+++ b/bundler.fish
@@ -4,7 +4,6 @@ function init --on-event init_bundler
                capify        \
                cucumber      \
                dashing       \
-               foreman       \
                guard         \
                kitchen       \
                middleman     \


### PR DESCRIPTION
> Ruby users should take care not to install foreman in their project's Gemfile.

Reference: https://github.com/ddollar/foreman
