### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/__is_a_bundled_executable.fish
+++ b/__is_a_bundled_executable.fish
@@ -1,5 +1,5 @@
 function __is_a_bundled_executable
-  if available bundle
+  if type -q bundle
     set -l bindir (command bundle exec ruby -e "puts Gem.bindir")
     test -f "$bindir/$argv"
   else


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
